### PR TITLE
fix: pin sqlc to v1.29.0 for Go 1.24 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /go/src/app
 # Install Atlas CLI and other tools
 RUN apk add --no-cache curl && \
     curl -sSf https://atlasgo.sh | sh -s -- --yes && \
-    go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest && \
+    go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.29.0 && \
     go install github.com/swaggo/swag/cmd/swag@latest
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
sqlc@latest now resolves to v1.31.1, which requires Go >= 1.26.0
and fails to build on the golang:1.24-alpine base image with
GOTOOLCHAIN=local. Pin to v1.29.0, the last release compatible
with Go 1.24.

https://claude.ai/code/session_01KTvV2FsjPusaHbUd3L8cFS