### PR TITLE
ci: bump Go to 1.25 and golangci-lint to 2.11

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           check-latest: true
           cache: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN bun run docs:build
 
 
 # Build Go binary
-FROM golang:1.24-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /go/src/app
 
 # Install Atlas CLI and other tools

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Access at `http://localhost:1323`
 
 ### Tech Stack
 **Backend**
-[![Go](https://img.shields.io/badge/Go-1.24.6-00ADD8?logo=go)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go)](https://go.dev/)
 [![Echo](https://img.shields.io/badge/Echo-v4.11-blue)](https://echo.labstack.com/)
 [![ParadeDB](https://img.shields.io/badge/ParadeDB-1.0-orange)](https://www.paradedb.com/)
 

--- a/cmd/recally/README.md
+++ b/cmd/recally/README.md
@@ -16,7 +16,7 @@ A standalone command-line tool for saving web articles as markdown files with fu
 ### From Source
 
 **Prerequisites:**
-- [Go 1.24+](https://go.dev/dl/)
+- [Go 1.25+](https://go.dev/dl/)
 - [mise](https://mise.jit.su/) (recommended for development)
 
 **Using mise (recommended):**

--- a/mise.toml
+++ b/mise.toml
@@ -3,11 +3,11 @@
 # ============================================
 [tools]
 # Core runtimes
-go = "1.24"  # From go.mod
+go = "1.25"  # From go.mod
 bun = "1.3"
 # Go development tools
 "ubi:sqlc-dev/sqlc" = "1.29.0"
-"ubi:golangci/golangci-lint" = "2.2"
+"ubi:golangci/golangci-lint" = "2.11"
 "ubi:swaggo/swag" = "1.16.5"
 # Database tools
 atlas = "0.36.0"


### PR DESCRIPTION
PR #57 (jackc/pgx/v5 5.7.2 → 5.9.2) bumped go.mod's Go directive to
1.25.0, but mise.toml was still pinning Go 1.24 and golangci-lint 2.2
(built with Go 1.24). golangci-lint refuses to lint a module whose
target Go version is newer than the toolchain it was built with,
producing "Process completed with exit code 3" on every CI run since
9978d9e.

Bump mise.toml to Go 1.25 and golangci-lint 2.11 (built with Go 1.26)
so the lint step matches go.mod again.