### PR TITLE
ci: fix Docker build, harden Railway deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       service:
         description: 'Railway service name'
         required: true
-        default: 'recally-web'
+        default: 'recally'
 
 concurrency:
   group: railway-production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,32 +3,24 @@ name: Deploy to Railway
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Railway environment to deploy to'
-        required: true
-        default: 'dev'
-        type: choice
-        options:
-          - dev
-          - production
       service:
         description: 'Railway service name'
         required: true
         default: 'recally-web'
 
 concurrency:
-  group: railway-${{ inputs.environment }}
+  group: railway-production
   cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: production
 
     env:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-      RAILWAY_ENVIRONMENT: ${{ inputs.environment }}
+      RAILWAY_ENVIRONMENT: production
       RAILWAY_SERVICE: ${{ inputs.service }}
 
     steps:
@@ -41,7 +33,7 @@ jobs:
       - name: Verify Railway token is configured
         run: |
           if [ -z "$RAILWAY_API_TOKEN" ] && [ -z "$RAILWAY_TOKEN" ]; then
-            echo "::error::Neither RAILWAY_API_TOKEN nor RAILWAY_TOKEN is set in the '${RAILWAY_ENVIRONMENT}' environment secrets."
+            echo "::error::Neither RAILWAY_API_TOKEN nor RAILWAY_TOKEN is set in the 'production' environment secrets."
             exit 1
           fi
           if [ -n "$RAILWAY_API_TOKEN" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
     environment: ${{ inputs.environment }}
 
     env:
+      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_ENVIRONMENT: ${{ inputs.environment }}
       RAILWAY_SERVICE: ${{ inputs.service }}
@@ -37,8 +38,15 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Verify Railway auth
-        run: railway whoami
+      - name: Verify Railway token is configured
+        run: |
+          if [ -z "$RAILWAY_API_TOKEN" ] && [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::Neither RAILWAY_API_TOKEN nor RAILWAY_TOKEN is set in the '${RAILWAY_ENVIRONMENT}' environment secrets."
+            exit 1
+          fi
+          if [ -n "$RAILWAY_API_TOKEN" ]; then
+            railway whoami
+          fi
 
       - name: Deploy to Railway
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,9 @@ jobs:
       packages: write
       id-token: write
 
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,7 +53,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        id: dockerhub_login
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -63,7 +67,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            recally/recally
+            name=recally/recally,enable=${{ steps.dockerhub_login.outcome == 'success' }}
             ghcr.io/${{ github.repository }}
           tags: |
             # https://github.com/docker/metadata-action#tags-input
@@ -89,5 +93,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=registry,ref=recally/recally:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && 'type=registry,ref=recally/recally:buildcache,mode=max' || 'type=local,dest=/tmp/.buildx-cache' }}
+          cache-from: type=gha
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || 'type=local,dest=/tmp/.buildx-cache' }}


### PR DESCRIPTION
## Summary
- Skip DockerHub publish when its credentials aren't configured (the build was failing at the `Login to DockerHub` step on every push to main); always push to GHCR; switch buildx cache from the DockerHub registry to GitHub Actions cache.
- Make the Railway deploy workflow accept either `RAILWAY_API_TOKEN` (account/team) or `RAILWAY_TOKEN` (project) and emit a clean `::error::` if neither is set; the previous `railway whoami` step failed with an opaque error when given a project token.
- Drop the `dev` environment choice — deploys always target `production`.
- Default the Railway service to `recally`.

## Test plan
- [ ] Push triggers `Build and Push Docker Image` and it succeeds, publishing to `ghcr.io/recally-io/recally`.
- [ ] After adding `RAILWAY_TOKEN` to the `production` environment, manually run `Deploy to Railway` and verify the deploy completes.

https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b)_