### PR TITLE
ci(deploy): restore service default to 'recally-web'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       service:
         description: 'Railway service name'
         required: true
-        default: 'recally'
+        default: 'recally-web'
 
 concurrency:
   group: railway-production


### PR DESCRIPTION
## Summary
The merged PR #62 changed the Railway service default to `recally`, but the Railway project actually has services `recally-web`, `Postgres`, and `browser` — no service named `recally`. That's why deploy run #7 failed at `railway up`. Restoring the original `recally-web` default.

## Test plan
- [ ] Manually run `Deploy to Railway` and verify `railway up --service recally-web --environment production` succeeds.

https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b)_