### PR TITLE
ci(deploy): add railway.toml pinning Dockerfile builder

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,7 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Why
Deploy run #8 failed with:
```
✖ Railpack could not determine how to build the app.
```
The `recally-web` Railway service was reconfigured to use the `RAILPACK` auto-detector, but Railpack can't analyse this multi-stage Go + Bun project. The Feb 14 successful deploy used `builder: DOCKERFILE`.

## Fix
Add a `railway.toml` at the repo root that pins the project-level config:
- `builder = "DOCKERFILE"`, `dockerfilePath = "Dockerfile"` — restores the working build path
- `restartPolicyType = "ON_FAILURE"`, `restartPolicyMaxRetries = 10` — matches the Feb 14 deploy

Project config overrides service-level settings, so the next `railway up` will build via the existing Dockerfile regardless of what the dashboard says.

## Test plan
- [ ] Manually run `Deploy to Railway` and confirm the build proceeds past the Railpack stage and runs the Dockerfile build.

https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b)_