### PR TITLE
ci(deploy): use --detach for railway up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,5 @@ jobs:
         run: |
           railway up \
             --service "$RAILWAY_SERVICE" \
-            --environment "$RAILWAY_ENVIRONMENT"
+            --environment "$RAILWAY_ENVIRONMENT" \
+            --detach


### PR DESCRIPTION
## Why
Deploy run #9 failed at the `Deploy to Railway` step in 9 seconds without ever creating a Railway deployment, even though the railway.toml from PR #64 was in place. Locally the same `railway up` command works fine — it just takes ~2 minutes to complete because the multi-stage Go + Bun Dockerfile takes that long to build, and `railway up` (without `--detach`) streams build logs and waits.

The streaming behaviour is fragile in CI. Run #9's `railway up` likely died on the long-running stream before queuing a deployment.

## Fix
Pass `--detach` so `railway up` exits as soon as the upload is queued. Build progress can be watched on Railway directly.

## Verified
Manually ran `railway up --service recally-web --environment production` from /home/user/recally (with the project token and the new railway.toml) and it built successfully end-to-end (image digest `sha256:6507be08…`), confirming both the project config and the credentials work for the real codebase.

## Test plan
- [ ] Manually run `Deploy to Railway` and confirm the workflow exits successfully within ~30s, with the build then proceeding async on Railway.

https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b)_