### PR TITLE
ci(deploy): auto-deploy on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy to Railway
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       service:
@@ -21,7 +23,7 @@ jobs:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_ENVIRONMENT: production
-      RAILWAY_SERVICE: ${{ inputs.service }}
+      RAILWAY_SERVICE: ${{ inputs.service || 'recally-web' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Why
The deploy workflow is currently `workflow_dispatch` only, so it has to be triggered by a human in the Actions UI. Add `push: branches: [main]` so every merge to main auto-deploys, matching the `Build and Push Docker Image` workflow's trigger pattern.

## Changes
- Add `push: branches: [main]` to the trigger list (workflow_dispatch retained for manual reruns).
- `RAILWAY_SERVICE` falls back to `'recally-web'` when `inputs.service` is empty (push events have no inputs).

## Test plan
- [ ] Merging this PR should trigger a `Deploy to Railway` run automatically. The run should exit successfully (`--detach` is already in place from PR #65), and a new BUILDING/SUCCESS deployment should appear in Railway.

https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b)_