### PR TITLE
ci(deploy): add diagnostic logging for failed runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,11 @@ jobs:
 
       - name: Verify Railway token is configured
         run: |
+          echo "RAILWAY_API_TOKEN length: ${#RAILWAY_API_TOKEN}"
+          echo "RAILWAY_TOKEN length: ${#RAILWAY_TOKEN}"
+          echo "RAILWAY_SERVICE: $RAILWAY_SERVICE"
+          echo "RAILWAY_ENVIRONMENT: $RAILWAY_ENVIRONMENT"
+          railway --version
           if [ -z "$RAILWAY_API_TOKEN" ] && [ -z "$RAILWAY_TOKEN" ]; then
             echo "::error::Neither RAILWAY_API_TOKEN nor RAILWAY_TOKEN is set in the 'production' environment secrets."
             exit 1
@@ -44,6 +49,7 @@ jobs:
 
       - name: Deploy to Railway
         run: |
+          set -x
           railway up \
             --service "$RAILWAY_SERVICE" \
             --environment "$RAILWAY_ENVIRONMENT" \


### PR DESCRIPTION
## Why
Run #10 still failed in 7 seconds without creating a Railway deployment, even with the railway.toml and --detach fixes in place. The actual error message isn't accessible from outside the repo's auth scope, so add diagnostic output to the workflow itself.

## Changes
- `Verify Railway token`: print token *length* (not value), service, environment, and `railway --version`. Length lets us tell "secret unset" from "secret set to wrong value".
- `Deploy to Railway`: `set -x` so the `railway up` invocation and stderr are visible.

## Test plan
- [ ] Merge → push triggers run. Inspect the new run's log: token length should be > 0; if it's 0, the secret isn't set in the `production` environment.

https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b

---
_Generated by [Claude Code](https://claude.ai/code/session_014BE7MM1WWrvFwN2FdhWu5b)_